### PR TITLE
Ensure test results are sorted alphabetically.

### DIFF
--- a/html-generator/src/main/groovy/com/github/damagecontrol/report/htmlgenerator/TestResults.groovy
+++ b/html-generator/src/main/groovy/com/github/damagecontrol/report/htmlgenerator/TestResults.groovy
@@ -2,7 +2,7 @@ package com.github.damagecontrol.report.htmlgenerator
 
 class TestResults {
 
-    final specs = [:]
+    final specs = new TreeMap()
 
     def spec(specName) {
         specs[specName] = specs[specName] ?: new Spec(name: specName)


### PR DESCRIPTION
The specs listed in the reports tend to be listed in random order for me, so I dug into this and found that this one-line change would sort the specs alphabetically (via the built-in sort order of String).

I'd love to see this get merged somewhat soonish, but decision and timing is up to you. Thanks for considering this.
